### PR TITLE
Add mock Command Center UI with unit tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # simulon-command
 The Simulon Command Center.
+
+## Mock UI
+Open `index.html` in a browser to view a mock command center with tabs for units.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,11 @@
+document.querySelectorAll('.tab-button').forEach(button => {
+  button.addEventListener('click', () => {
+    const tabId = button.getAttribute('data-tab');
+
+    document.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
+
+    button.classList.add('active');
+    document.getElementById(tabId).classList.add('active');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Simulon Command Center</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Simulon Command Center</h1>
+  <div class="tabs">
+    <button class="tab-button active" data-tab="alpha">Unit Alpha</button>
+    <button class="tab-button" data-tab="beta">Unit Beta</button>
+    <button class="tab-button" data-tab="gamma">Unit Gamma</button>
+  </div>
+  <div class="tab-content active" id="alpha">
+    <h2>Unit Alpha</h2>
+    <p>Status: Ready</p>
+  </div>
+  <div class="tab-content" id="beta">
+    <h2>Unit Beta</h2>
+    <p>Status: Deploying</p>
+  </div>
+  <div class="tab-content" id="gamma">
+    <h2>Unit Gamma</h2>
+    <p>Status: Standby</p>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 20px;
+}
+
+.tabs {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.tab-button {
+  padding: 10px 20px;
+  border: none;
+  background: #ddd;
+  cursor: pointer;
+}
+
+.tab-button.active {
+  background: #fff;
+  border-bottom: 2px solid #000;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add initial mock of Simulon Command Center UI with tabs for Units Alpha, Beta, and Gamma
- include basic styling and JavaScript for tab switching
- document how to open the mock UI in the README

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fc5fe448832d8486a9462e7ab7a4