### PR TITLE
Add basic SimuLang console to update unit statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ The Simulon Command Center.
 
 ## Mock UI
 Open `index.html` in a browser to view a mock command center with tabs for units.
+
+## SimuLang
+The page includes a simple SimuLang console. Enter commands such as:
+
+```
+SET alpha Deployed
+SET beta Ready
+```
+
+Each `SET` command updates the status text for the specified unit.

--- a/app.js
+++ b/app.js
@@ -9,3 +9,9 @@ document.querySelectorAll('.tab-button').forEach(button => {
     document.getElementById(tabId).classList.add('active');
   });
 });
+
+document.getElementById('run-simulang').addEventListener('click', () => {
+  const script = document.getElementById('simulang-input').value;
+  const output = window.runSimuLang(script);
+  document.getElementById('simulang-output').textContent = output;
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,14 @@
     <h2>Unit Gamma</h2>
     <p>Status: Standby</p>
   </div>
+  <div id="simulang-console">
+    <h2>SimuLang Console</h2>
+    <textarea id="simulang-input" rows="5" cols="40" placeholder="Enter SimuLang commands..."></textarea>
+    <br>
+    <button id="run-simulang">Run Script</button>
+    <pre id="simulang-output"></pre>
+  </div>
+  <script src="simulang.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/simulang.js
+++ b/simulang.js
@@ -1,0 +1,24 @@
+function runSimuLang(script) {
+  const output = [];
+  const lines = script.split(/\n/).map(l => l.trim()).filter(Boolean);
+  lines.forEach((line, idx) => {
+    const parts = line.split(/\s+/);
+    const cmd = parts[0]?.toUpperCase();
+    if (cmd === 'SET' && parts.length >= 3) {
+      const unit = parts[1].toLowerCase();
+      const status = parts.slice(2).join(' ');
+      const unitEl = document.querySelector(`#${unit} p`);
+      if (unitEl) {
+        unitEl.textContent = `Status: ${status}`;
+        output.push(`Line ${idx + 1}: set ${unit} to ${status}`);
+      } else {
+        output.push(`Line ${idx + 1}: unknown unit ${parts[1]}`);
+      }
+    } else {
+      output.push(`Line ${idx + 1}: unknown command`);
+    }
+  });
+  return output.join('\n');
+}
+
+window.runSimuLang = runSimuLang;

--- a/style.css
+++ b/style.css
@@ -28,3 +28,19 @@ body {
 .tab-content.active {
   display: block;
 }
+
+#simulang-console {
+  margin-top: 20px;
+}
+
+#simulang-input {
+  width: 100%;
+  max-width: 400px;
+}
+
+#simulang-output {
+  background: #f5f5f5;
+  padding: 10px;
+  white-space: pre-wrap;
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- integrate a simple SimuLang interpreter that can set unit status text
- add SimuLang console UI with textarea, run button and output display
- document how to use SimuLang commands

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4ffe3f4b8832d8b73cc4fc9bbd828